### PR TITLE
Reuse promoted-offers component #19

### DIFF
--- a/mixins/ComponentFilterMixin.js
+++ b/mixins/ComponentFilterMixin.js
@@ -1,0 +1,18 @@
+import { mapGetters } from 'vuex'
+
+export default {
+  computed: {
+    ...mapGetters(
+      {cmsHomeComponents: 'cmsstore/getHomeComponents'}
+    )
+  },
+  methods: {
+    filterCmsComponents (component) {
+      return this.cmsHomeComponents['components'].find(e => {
+        if (e.type === component) {
+          return e.data
+        }
+      })
+    }
+  }
+}


### PR DESCRIPTION
1.Home.vue using page based cms-data to show components.
2.promoted-offers is part of home page data.
3.created componentFilterMixin to filter data.
4.componentFilterMixin provide only promoted-offers data to product.vue/promoted-offers component.