### PR TITLE
Return-policy link not working #21

### DIFF
--- a/router/beforeEach.ts
+++ b/router/beforeEach.ts
@@ -3,7 +3,7 @@ import { Route } from 'vue-router'
 /**
  * Add Route's name in peregrineRoutes whose data will come from peregrine cms
  */
-const peregrineRoutes = ['returns-policy', 'size-guide', 'about-us', 'contact', 'privacy', 'legal', 'customer-service', 'delivery']
+const peregrineRoutes = ['returns', 'size-guide', 'about-us', 'contact', 'privacy', 'legal', 'customer-service', 'delivery']
 export async function beforeEach(to: Route, from: Route, next) {
     let isCmsRoute = peregrineRoutes.findIndex(route => route === to.name)
     if (isCmsRoute > -1) {


### PR DESCRIPTION
1. getting api endpoint returns so changed return policy to returns in hooks.