### PR TITLE
Improved: Renamed the ComponentRenderer to CmsPage (3bk812)

### DIFF
--- a/components/CmsPage.vue
+++ b/components/CmsPage.vue
@@ -3,7 +3,7 @@
     <div v-for="(component, index) in cmsObject.components" :key="index">
       <component
         v-bind:is="cmsComponent[component.type]"
-        :componentData="component"
+        :componentData="component.data"
       />
     </div>
   </div>

--- a/index.ts
+++ b/index.ts
@@ -6,11 +6,8 @@ import { StorefrontModule } from '@vue-storefront/core/lib/modules';
 
 export const KEY = 'cmsstore'
 export const PeregrineModule: StorefrontModule = function ({
-  app,
   store,
-  router,
-  moduleConfig,
-  appConfig
+  router
 }) {
   store.registerModule(KEY, module)
   router.beforeEach(beforeEach)

--- a/pages/Static.vue
+++ b/pages/Static.vue
@@ -1,7 +1,7 @@
 <template>
-  <div v-if="cmsComponents">
+  <div id="static" v-if="cmsComponents">
     <div>
-      <ComponentRenderer :cmsObject="cmsComponents" />
+      <CmsPage :cmsObject="cmsComponents" />
     </div>
   </div>
 </template>
@@ -10,31 +10,20 @@
 import i18n from "@vue-storefront/i18n";
 import config from "config";
 import { mapGetters } from "vuex";
-import ComponentRenderer from "../components/ComponentRenderer";
+import CmsPage from "../components/CmsPage";
 
 export default {
   components: {
-    ComponentRenderer
+    CmsPage
   },
   metaInfo() {
     return {
-      title: this.$route.meta.title || this.$props.title,
+      title: this.$route.meta.title,
       meta: this.$route.meta.description
         ? [{ vmid: "description", description: this.$route.meta.description }]
         : []
     };
   },
-  props: {
-    title: {
-      type: String,
-      required: true
-    },
-    page: {
-      type: String,
-      required: true
-    }
-  },
-  mounted() {},
   computed: {
     ...mapGetters({
       cmsComponents: "cmsstore/getComponents"
@@ -42,3 +31,23 @@ export default {
   }
 };
 </script>
+
+<style lang="scss" scoped>
+@import "~@storefront-ui/shared/styles/helpers/breakpoints";
+
+#static {
+  box-sizing: border-box;
+  @include for-desktop {
+    max-width: 1272px;
+    padding: 0 var(--spacer-sm);
+    margin: 0 auto;
+  }
+  --content-pages-height: auto;
+  ::v-deep {
+    .sf-content-pages__content,
+    .sf-content-pages__sidebar {
+      height: min-content;
+    }
+  }
+}
+</style>


### PR DESCRIPTION
The inspiration behind this is Shopware PWA implementation from Divante for CMS
https://github.com/DivanteLtd/shopware-pwa/tree/master/packages/default-theme/cms

Also added the styles which are used for the Static page in the Capybara theme and removed unused code.