### PR TITLE
Implemented: Banner Component using Storefront UI (3btkj6)

### DIFF
--- a/components/CmsPage.vue
+++ b/components/CmsPage.vue
@@ -4,6 +4,7 @@
       <component
         v-bind:is="cmsComponent[component.type]"
         :componentData="component.data"
+        :componentType="component.type"
       />
     </div>
   </div>
@@ -12,6 +13,7 @@
 <script>
 import i18n from "@vue-storefront/i18n";
 const TextBlock = () => import('./organisms/o-text-block')
+const Banner = () => import('./molecules/m-banner')
 
 export default {
   props: {
@@ -22,7 +24,9 @@ export default {
   data() {
     return {
       cmsComponent: {
-        'richtext': TextBlock
+        'richtext': TextBlock,
+        'bannerleft': Banner,
+        'bannerright': Banner
       }
     };
   }

--- a/components/molecules/m-banner.vue
+++ b/components/molecules/m-banner.vue
@@ -21,7 +21,7 @@
 import { SfBanner } from "@storefront-ui/vue"
 import config from "config"
 import LinkMixin from "../../mixins/LinkMixin"
-import imageMixin from "../../mixins/imageMixin";
+import imageMixin from "../../mixins/imageMixin"
 
 export default {
   components: {

--- a/components/molecules/m-banner.vue
+++ b/components/molecules/m-banner.vue
@@ -5,7 +5,7 @@
       :title="componentData.title"
       :description="componentData.text"
       :button-text="componentData.buttontext"
-      :image="image"
+      :image="image(componentData.imageLinkType, componentData.image)"
     />
   </a>
   <SfBanner
@@ -13,7 +13,7 @@
     :class="banner"
     :title="componentData.title"
     :description="componentData.text"
-    :image="image"
+    :image="image(componentData.imageLinkType, componentData.image)"
   />
 </template>
 
@@ -21,6 +21,7 @@
 import { SfBanner } from "@storefront-ui/vue"
 import config from "config"
 import LinkMixin from "../../mixins/LinkMixin"
+import imageMixin from "../../mixins/imageMixin";
 
 export default {
   components: {
@@ -35,12 +36,6 @@ export default {
     }
   },
   computed: {
-    image() {
-      if (this.componentData.imageLinkType === "internalLink")
-        return config.cms_peregrine.image_endpoint + this.componentData.image
-      else
-        return this.componentData.image
-    },
     banner() {
       if (this.componentType === "bannerright")
         return "sf-banner--right m-banner"
@@ -48,7 +43,7 @@ export default {
         return "m-banner";
     }
   },
-  mixins: [LinkMixin]
+  mixins: [LinkMixin, imageMixin]
 };
 </script>
 

--- a/components/molecules/m-banner.vue
+++ b/components/molecules/m-banner.vue
@@ -1,0 +1,61 @@
+<template>
+  <a v-if="componentData.link" @click="link(componentData)">
+    <SfBanner
+      :class="customClass"
+      :title="componentData.title"
+      :description="componentData.text"
+      :button-text="componentData.buttontext"
+      :image="image"
+    />
+  </a>
+  <SfBanner
+    v-else
+    :class="customClass"
+    :title="componentData.title"
+    :description="componentData.text"
+    :image="image"
+  />
+</template>
+
+<script>
+import { SfBanner } from "@storefront-ui/vue"
+import config from "config"
+import LinkMixin from "../../mixins/LinkMixin"
+
+export default {
+  components: {
+    SfBanner
+  },
+  props: {
+    componentData: {
+      type: Object
+    },
+    componentType: {
+      type: String
+    }
+  },
+  computed: {
+    image() {
+      if (this.componentData.imageLinkType === "internalLink")
+        return config.cms_peregrine.image_endpoint + this.componentData.image
+      else
+        return this.componentData.image
+    },
+    customClass() {
+      if (this.componentType === "bannerright")
+        return "sf-banner--right m-banner"
+      else
+        return "m-banner";
+    }
+  },
+  mixins: [LinkMixin]
+};
+</script>
+
+<style lang="scss" scoped>
+@import "~@storefront-ui/shared/styles/helpers/breakpoints";
+.m-banner {
+  margin: var(--spacer-xl) 0;
+  box-sizing: border-box;
+}
+</style>

--- a/components/molecules/m-banner.vue
+++ b/components/molecules/m-banner.vue
@@ -1,7 +1,7 @@
 <template>
   <a v-if="componentData.link" @click="link(componentData)">
     <SfBanner
-      :class="customClass"
+      :class="banner"
       :title="componentData.title"
       :description="componentData.text"
       :button-text="componentData.buttontext"
@@ -10,7 +10,7 @@
   </a>
   <SfBanner
     v-else
-    :class="customClass"
+    :class="banner"
     :title="componentData.title"
     :description="componentData.text"
     :image="image"
@@ -41,7 +41,7 @@ export default {
       else
         return this.componentData.image
     },
-    customClass() {
+    banner() {
       if (this.componentType === "bannerright")
         return "sf-banner--right m-banner"
       else

--- a/components/molecules/m-banner.vue
+++ b/components/molecules/m-banner.vue
@@ -40,7 +40,7 @@ export default {
       if (this.componentType === "bannerright")
         return "sf-banner--right m-banner"
       else
-        return "m-banner";
+        return "m-banner"
     }
   },
   mixins: [LinkMixin, imageMixin]

--- a/mixins/imageMixin.js
+++ b/mixins/imageMixin.js
@@ -1,0 +1,13 @@
+import config from 'config'
+
+export default {
+  methods: {
+    image (type, path) {
+      if (type === 'internalLink') {
+        return config.cms_peregrine.image_endpoint + path
+      } else {
+        return path
+      }
+    }
+  }
+}


### PR DESCRIPTION
Done following:
1.) Pass the componentType property, because we will be using single Banner component of Storefront UI for Banner Left and Banner Right.
Used 'sf-banner--right' class of Storefront UI for banner right.

2.) If the banner has a link, rendered it based on link type (internal or external using link mixin)

3.) The margin CSS is inspired by Capybara theme,
because when two banners used, they were not having any gap in between.

4.) Added the image mixin to render internal and external image.

https://github.com/DivanteLtd/vsf-capybara/blob/7ee67219d6c12da730b51bd7062ca893a2f47e0c/components/organisms/o-newsletter.vue#L56

@mohammad-k8, @iamaishwary

![Banner](https://user-images.githubusercontent.com/7145848/85291946-d3494d00-b4b8-11ea-8780-3ebb6c0c6aa9.png)
