### PR TITLE
Implemented: Banner Grid Component using Storefront UI (3btkkx)

### DIFF
--- a/components/CmsPage.vue
+++ b/components/CmsPage.vue
@@ -28,7 +28,8 @@ export default {
         'richtext': TextBlock,
         'bannerleft': Banner,
         'bannerright': Banner,
-        'verticalbannergrid': BannerGrid
+        'verticalbannergrid': BannerGrid,
+        'verticalset': BannerGrid
       }
     };
   }

--- a/components/CmsPage.vue
+++ b/components/CmsPage.vue
@@ -14,6 +14,7 @@
 import i18n from "@vue-storefront/i18n";
 const TextBlock = () => import('./organisms/o-text-block')
 const Banner = () => import('./molecules/m-banner')
+const BannerGrid = () => import('./organisms/o-banner-grid')
 
 export default {
   props: {
@@ -26,7 +27,8 @@ export default {
       cmsComponent: {
         'richtext': TextBlock,
         'bannerleft': Banner,
-        'bannerright': Banner
+        'bannerright': Banner,
+        'verticalbannergrid': BannerGrid
       }
     };
   }

--- a/components/CmsPage.vue
+++ b/components/CmsPage.vue
@@ -4,6 +4,7 @@
       <component
         v-bind:is="cmsComponent[component.type]"
         :componentData="component.data"
+        :componentType="component.type"
       />
     </div>
   </div>
@@ -12,6 +13,7 @@
 <script>
 import i18n from "@vue-storefront/i18n";
 const TextBlock = () => import('./organisms/o-text-block')
+const Banner = () => import('./molecules/m-banner')
 
 export default {
   props: {
@@ -22,7 +24,9 @@ export default {
   data() {
     return {
       cmsComponent: {
-        'richtext': TextBlock
+        'richtext': TextBlock,
+        'bannerleft': Banner,
+        'bannerright': Banner
       }
     };
   }

--- a/components/molecules/m-banner.vue
+++ b/components/molecules/m-banner.vue
@@ -21,7 +21,7 @@
 import { SfBanner } from "@storefront-ui/vue"
 import config from "config"
 import LinkMixin from "../../mixins/LinkMixin"
-import imageMixin from "../../mixins/imageMixin";
+import imageMixin from "../../mixins/imageMixin"
 
 export default {
   components: {

--- a/components/molecules/m-banner.vue
+++ b/components/molecules/m-banner.vue
@@ -5,7 +5,7 @@
       :title="componentData.title"
       :description="componentData.text"
       :button-text="componentData.buttontext"
-      :image="image"
+      :image="image(componentData.imageLinkType, componentData.image)"
     />
   </a>
   <SfBanner
@@ -13,7 +13,7 @@
     :class="banner"
     :title="componentData.title"
     :description="componentData.text"
-    :image="image"
+    :image="image(componentData.imageLinkType, componentData.image)"
   />
 </template>
 
@@ -21,6 +21,7 @@
 import { SfBanner } from "@storefront-ui/vue"
 import config from "config"
 import LinkMixin from "../../mixins/LinkMixin"
+import imageMixin from "../../mixins/imageMixin";
 
 export default {
   components: {
@@ -35,12 +36,6 @@ export default {
     }
   },
   computed: {
-    image() {
-      if (this.componentData.imageLinkType === "internalLink")
-        return config.cms_peregrine.image_endpoint + this.componentData.image
-      else
-        return this.componentData.image
-    },
     banner() {
       if (this.componentType === "bannerright")
         return "sf-banner--right m-banner"
@@ -48,7 +43,7 @@ export default {
         return "m-banner";
     }
   },
-  mixins: [LinkMixin]
+  mixins: [LinkMixin, imageMixin]
 };
 </script>
 

--- a/components/molecules/m-banner.vue
+++ b/components/molecules/m-banner.vue
@@ -1,0 +1,61 @@
+<template>
+  <a v-if="componentData.link" @click="link(componentData)">
+    <SfBanner
+      :class="customClass"
+      :title="componentData.title"
+      :description="componentData.text"
+      :button-text="componentData.buttontext"
+      :image="image"
+    />
+  </a>
+  <SfBanner
+    v-else
+    :class="customClass"
+    :title="componentData.title"
+    :description="componentData.text"
+    :image="image"
+  />
+</template>
+
+<script>
+import { SfBanner } from "@storefront-ui/vue"
+import config from "config"
+import LinkMixin from "../../mixins/LinkMixin"
+
+export default {
+  components: {
+    SfBanner
+  },
+  props: {
+    componentData: {
+      type: Object
+    },
+    componentType: {
+      type: String
+    }
+  },
+  computed: {
+    image() {
+      if (this.componentData.imageLinkType === "internalLink")
+        return config.cms_peregrine.image_endpoint + this.componentData.image
+      else
+        return this.componentData.image
+    },
+    customClass() {
+      if (this.componentType === "bannerright")
+        return "sf-banner--right m-banner"
+      else
+        return "m-banner";
+    }
+  },
+  mixins: [LinkMixin]
+};
+</script>
+
+<style lang="scss" scoped>
+@import "~@storefront-ui/shared/styles/helpers/breakpoints";
+.m-banner {
+  margin: var(--spacer-xl) 0;
+  box-sizing: border-box;
+}
+</style>

--- a/components/molecules/m-banner.vue
+++ b/components/molecules/m-banner.vue
@@ -1,7 +1,7 @@
 <template>
   <a v-if="componentData.link" @click="link(componentData)">
     <SfBanner
-      :class="customClass"
+      :class="banner"
       :title="componentData.title"
       :description="componentData.text"
       :button-text="componentData.buttontext"
@@ -10,7 +10,7 @@
   </a>
   <SfBanner
     v-else
-    :class="customClass"
+    :class="banner"
     :title="componentData.title"
     :description="componentData.text"
     :image="image"
@@ -41,7 +41,7 @@ export default {
       else
         return this.componentData.image
     },
-    customClass() {
+    banner() {
       if (this.componentType === "bannerright")
         return "sf-banner--right m-banner"
       else

--- a/components/organisms/o-banner-grid.vue
+++ b/components/organisms/o-banner-grid.vue
@@ -1,5 +1,5 @@
 <template>
-  <SfBannerGrid :banner-grid="1" class="banner-grid">
+  <SfBannerGrid :banner-grid="bannerGrid" class="banner-grid">
     <template v-for="(banner, bannerIndex) in banners" #[slotName(bannerIndex)]>
       <a v-if="banner.link" @click="link(banner)">
         <SfBanner
@@ -34,11 +34,20 @@ export default {
   props: {
     componentData: {
       type: Object
+    },
+    componentType: {
+      type: String
     }
   },
   computed: {
     banners() {
       return this.componentData.cards;
+    },
+    bannerGrid() {
+      if (this.componentType === "verticalbannergrid")
+        return 1
+      else if (this.componentType === "verticalset")
+        return 2
     }
   },
   mixins: [LinkMixin, imageMixin],

--- a/components/organisms/o-banner-grid.vue
+++ b/components/organisms/o-banner-grid.vue
@@ -1,0 +1,78 @@
+<template>
+  <SfBannerGrid :banner-grid="1" class="banner-grid">
+    <template v-for="(banner, bannerIndex) in banners" #[slotName(bannerIndex)]>
+      <a v-if="banner.link" @click="link(banner)">
+        <SfBanner
+          :subtitle="banner.subtitle"
+          :title="banner.title"
+          :description="banner.text"
+          :button-text="banner.buttontext"
+          :image="image(banner.imageLinkType, banner.image)"
+        />
+      </a>
+      <SfBanner
+        v-else
+        :subtitle="banner.subtitle"
+        :title="banner.title"
+        :description="banner.text"
+        :image="image(banner.imageLinkType, banner.image)"
+      />
+    </template>
+  </SfBannerGrid>
+</template>
+
+<script>
+import { SfBannerGrid, SfBanner } from "@storefront-ui/vue";
+import LinkMixin from "../../mixins/LinkMixin";
+import imageMixin from "../../mixins/imageMixin";
+
+export default {
+  components: {
+    SfBannerGrid,
+    SfBanner
+  },
+  props: {
+    componentData: {
+      type: Object
+    }
+  },
+  computed: {
+    banners() {
+      return this.componentData.cards;
+    }
+  },
+  mixins: [LinkMixin, imageMixin],
+  methods: {
+    /* The BannerGrid component has 4 Slots: banner-A, banner-B, banner-C, banner-D
+      Currently the CMS is not returning these attribute, thus slotName method is implemented.
+      After the implementation of https://app.clickup.com/t/3dqt60, we can remove this method.
+    */
+    slotName(bannerIndex) {
+      switch (bannerIndex) {
+        case 0:
+          return "banner-A";
+          break;
+        case 1:
+          return "banner-B";
+          break;
+        case 2:
+          return "banner-C";
+          break;
+        case 3:
+          return "banner-D";
+          break;
+      }
+    }
+  }
+};
+</script>
+
+<style lang="scss" scoped>
+@import "~@storefront-ui/shared/styles/helpers/breakpoints";
+.banner-grid {
+  margin: var(--spacer-base) 0;
+  @include for-desktop {
+    margin: var(--spacer-2xl) 0;
+  }
+}
+</style>

--- a/mixins/imageMixin.js
+++ b/mixins/imageMixin.js
@@ -1,0 +1,13 @@
+import config from 'config'
+
+export default {
+  methods: {
+    image (type, path) {
+      if (type === 'internalLink') {
+        return config.cms_peregrine.image_endpoint + path
+      } else {
+        return path
+      }
+    }
+  }
+}


### PR DESCRIPTION
Done following:
1.) Used SfBannerGrid, SfBanner component from Strorefront UI.

2.) Added the slotName method, which return the slot name based on index of banner

The BannerGrid component has 4 Slots: banner-A, banner-B, banner-C, banner-D Currently the CMS is not returning these attribute, thus slotName method is implemented.
After the implementation of https://app.clickup.com/t/3dqt60, we can remove this method.

3.) The CSS (banner-grid class) is inspired by Capybara theme to having margin for the component.


![BannerGrid](https://user-images.githubusercontent.com/7145848/85525643-e4b06780-b626-11ea-9373-007e0dc649ae.png)

Banner Grid (Vertical)
![BannerGrid Vertical](https://user-images.githubusercontent.com/7145848/85700783-560d1a80-b6fa-11ea-81f0-166f33bee55a.png)


CC: @mohammad-k8, @iamaishwary