### PR TITLE
Improved: Handled the appended i in the router (3fkmu9)

### DIFF
--- a/router/beforeEach.ts
+++ b/router/beforeEach.ts
@@ -5,9 +5,13 @@ import { Route } from 'vue-router'
  */
 const peregrineRoutes = ['returns', 'size-guide', 'about-us', 'contact', 'privacy', 'legal', 'customer-service', 'delivery']
 export async function beforeEach (to: Route, from: Route, next) {
-  let isCmsRoute = peregrineRoutes.findIndex(route => route === to.name)
+  let routeTo = to.name
+  if (routeTo === 'cms-page') {
+    routeTo = to.params.slug
+  }
+  let isCmsRoute = peregrineRoutes.findIndex(route => route === routeTo)
   if (isCmsRoute > -1) {
-    await store.dispatch('cmsstore/getCmsComponents', { title: to.name })
+    await store.dispatch('cmsstore/getCmsComponents', { title: routeTo })
   }
   next()
 }


### PR DESCRIPTION
To handle the static pages for multistore, Vue Storefront append i in the path and routed to cms-page (and the pass the actual page name as slug parameter)
In our case, we are using the router path to prepare CMS URL,
thus if the path is 'cms-page', we fetch the actual page name from slug parameter and used it to fetch data from CMS.