### PR TITLE
Implemented: T-Grid Banner Component (3dutnn)

### DIFF
--- a/components/CmsPage.vue
+++ b/components/CmsPage.vue
@@ -16,6 +16,7 @@ const TextBlock = () => import('./organisms/o-text-block')
 const Newsletter = () => import('./organisms/o-newsletter')
 const Banner = () => import('./molecules/m-banner')
 const BannerGrid = () => import('./organisms/o-banner-grid')
+const BannerGridT = () => import('./organisms/o-banner-grid-t')
 
 export default {
   props: {
@@ -31,7 +32,8 @@ export default {
         'bannerleft': Banner,
         'bannerright': Banner,
         'verticalbannergrid': BannerGrid,
-        'verticalset': BannerGrid
+        'verticalset': BannerGrid,
+        'tgrid': BannerGridT
       }
     };
   }

--- a/components/organisms/o-banner-grid-t.vue
+++ b/components/organisms/o-banner-grid-t.vue
@@ -1,0 +1,113 @@
+<template>
+  <div class="banner-grid sf-banner-grid">
+    <div class="sf-banner-grid__row">
+      <div class="sf-banner-grid__col">
+        <a v-if="banners[0].link" @click="link(banners[0])">
+          <SfBanner
+            :subtitle="banners[0].subtitle"
+            :title="banners[0].title"
+            :description="banners[0].text"
+            :button-text="banners[0].buttontext"
+            :image="image(banners[0].imageLinkType, banners[0].image)"
+          />
+        </a>
+        <SfBanner
+          v-else
+          :subtitle="banners[0].subtitle"
+          :title="banners[0].title"
+          :description="banners[0].text"
+          :image="image(banners[0].imageLinkType, banners[0].image)"
+        />
+      </div>
+    </div>
+    <div class="sf-banner-grid__row">
+      <div class="sf-banner-grid__col">
+        <a v-if="banners[1].link" @click="link(banners[1])">
+          <SfBanner
+            :subtitle="banners[1].subtitle"
+            :title="banners[1].title"
+            :description="banners[1].text"
+            :button-text="banners[1].buttontext"
+            :image="image(banners[1].imageLinkType, banners[1].image)"
+          />
+        </a>
+        <SfBanner
+          v-else
+          :subtitle="banners[1].subtitle"
+          :title="banners[1].title"
+          :description="banners[1].text"
+          :image="image(banners[1].imageLinkType, banners[1].image)"
+        />
+      </div>
+      <div class="sf-banner-grid__col">
+        <a v-if="banners[2].link" @click="link(banners[2])">
+          <SfBanner
+            :subtitle="banners[2].subtitle"
+            :title="banners[2].title"
+            :description="banners[2].text"
+            :button-text="banners[2].buttontext"
+            :image="image(banners[2].imageLinkType, banners[2].image)"
+          />
+        </a>
+        <SfBanner
+          v-else
+          :subtitle="banners[2].subtitle"
+          :title="banners[2].title"
+          :description="banners[2].text"
+          :image="image(banners[2].imageLinkType, banners[2].image)"
+        />
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+import { SfBanner } from "@storefront-ui/vue";
+import LinkMixin from "../../mixins/LinkMixin";
+import imageMixin from "../../mixins/imageMixin";
+
+export default {
+  components: {
+    SfBanner
+  },
+  props: {
+    componentData: {
+      type: Object
+    },
+    componentType: {
+      type: String
+    }
+  },
+  computed: {
+    banners() {
+      return this.componentData.cards;
+    }
+  },
+  mixins: [LinkMixin, imageMixin]
+};
+</script>
+
+<style lang="scss" scoped>
+@import "~@storefront-ui/shared/styles/helpers/breakpoints";
+
+.banner-grid {
+  margin: var(--spacer-base) 0;
+  @include for-desktop {
+    margin: var(--spacer-2xl) 0;
+  }
+}
+
+.sf-banner-grid {
+  --banner-container-width: 50%;
+  &__row {
+    & + & {
+      --banner-grid-row-margin: var(--spacer-sm) 0 0 0;
+    }
+    @media (min-width: $desktop-min) {
+      & + & {
+        --banner-grid-row-margin: var(--spacer-xl) 0 0 0;
+      }
+    }
+  }
+}
+</style>


### PR DESCRIPTION
Used the Banner Grid for implementing T-Grid banner.
The styles used in inspired from SfBannerGrid of Storefront UI

https://github.com/DivanteLtd/storefront-ui/blob/develop/packages/shared/styles/components/organisms/SfBannerGrid.scss

Once the https://github.com/DivanteLtd/storefront-ui/issues/1269 is implemented in Storefront OOTB, we will no longer need this custom implementation.