### PR TITLE
Implemented: Enabled the SSR for home page (3ktguh)

### DIFF
--- a/pages/Static.vue
+++ b/pages/Static.vue
@@ -26,8 +26,19 @@ export default {
   },
   computed: {
     ...mapGetters({
+      isLoggedIn: 'user/isLoggedIn',
       cmsComponents: 'cmsstore/getComponents'
     })
+  },
+  watch: {
+    isLoggedIn () {
+      const redirectObj = localStorage.getItem('redirect');
+      if (redirectObj) this.$router.push(redirectObj);
+      localStorage.removeItem('redirect');
+    }
+  },
+  mounted () {
+    if (!this.isLoggedIn && localStorage.getItem('redirect')) { this.$bus.$emit('modal-show', 'modal-signup'); }
   }
 };
 </script>

--- a/router/beforeEach.ts
+++ b/router/beforeEach.ts
@@ -3,7 +3,7 @@ import { Route } from 'vue-router'
 /**
  * Add Route's name in peregrineRoutes whose data will come from peregrine cms
  */
-const peregrineRoutes = ['returns', 'size-guide', 'about-us', 'contact', 'privacy', 'legal', 'customer-service', 'delivery']
+const peregrineRoutes = ['home', 'returns', 'size-guide', 'about-us', 'contact', 'privacy', 'legal', 'customer-service', 'delivery']
 export async function beforeEach (to: Route, from: Route, next) {
   let routeTo = to.name
   if (routeTo === 'cms-page') {
@@ -11,6 +11,9 @@ export async function beforeEach (to: Route, from: Route, next) {
   }
   let isCmsRoute = peregrineRoutes.findIndex(route => route === routeTo)
   if (isCmsRoute > -1) {
+    if (routeTo === 'home') {
+      routeTo = 'index'
+    }
     await store.dispatch('cmsstore/getCmsComponents', { title: routeTo })
   }
   next()


### PR DESCRIPTION
The SSR on the home page was not working because of async use of created lifecycle hook for data fetching required for components.

Done following:
1.) Use the Static page for Home because the nature of both the pages are the same, both consumes data from Peregrine CMS.
Note: The SSR was already handled properly for static pages.

2.) Put the redirection logic on the basis isLoggedIn put on the static page as well, this code is inspired by the existing home page in Capybara.

3.) Add the logic to fetch the index.data.json path of Peregrine CMS if the home page is rendered because in CMS side we have page named as index for home.