### PR TITLE
Removed: Overridden styling on home page (#19cy9n)

### DIFF
--- a/components/CmsPage.vue
+++ b/components/CmsPage.vue
@@ -1,5 +1,5 @@
 <template>
-  <div v-if="cmsObject" id="static">
+  <div v-if="cmsObject" id="static" class="global--max-width">
     <div v-for="(component, index) in cmsObject.components" :key="index">
       <component
         :is="cmsComponent[component.type]"
@@ -53,7 +53,6 @@ export default {
 #static {
   box-sizing: border-box;
   @include for-desktop {
-    max-width: 1272px;
     margin: 0 auto;
   }
   padding: 0 var(--spacer-sm);

--- a/components/organisms/o-carousel.vue
+++ b/components/organisms/o-carousel.vue
@@ -48,7 +48,6 @@ export default {
 
 <style lang="scss" scoped>
 .sf-hero-item {
-  --hero-item-height: 14rem;
   height: initial;
 }
 </style>

--- a/components/organisms/o-product-carousel.vue
+++ b/components/organisms/o-product-carousel.vue
@@ -93,12 +93,4 @@ export default {
 <style lang="scss" scoped>
 @import "~@storefront-ui/shared/styles/helpers/breakpoints";
 
-.section {
-  padding-left: var(--spacer-xl);
-  padding-right: var(--spacer-xl);
-  @include for-desktop {
-    padding-left: 0;
-    padding-right: 0;
-  }
-}
 </style>

--- a/pages/Home.vue
+++ b/pages/Home.vue
@@ -72,7 +72,6 @@ export default {
   box-sizing: border-box;
   padding: 0 var(--spacer-sm);
   @include for-desktop {
-    padding: 0 var(--spacer-sm);
     max-width: 1272px;
     margin: 0 auto;
   }

--- a/pages/Home.vue
+++ b/pages/Home.vue
@@ -1,5 +1,5 @@
 <template>
-  <div id="home" v-if="cmsComponents">
+  <div id="home" class="global--max-width" v-if="cmsComponents">
     <div>
       <CmsPage :cms-object="cmsComponents" />
     </div>
@@ -72,7 +72,7 @@ export default {
   box-sizing: border-box;
   padding: 0 var(--spacer-sm);
   @include for-desktop {
-    max-width: 1272px;
+    padding: 0 var(--spacer-sm);
     margin: 0 auto;
   }
 }

--- a/pages/Static.vue
+++ b/pages/Static.vue
@@ -1,5 +1,5 @@
 <template>
-  <div id="static" v-if="cmsComponents">
+  <div id="static" class="global--max-width" v-if="cmsComponents">
     <div>
       <CmsPage :cms-object="cmsComponents" />
     </div>
@@ -49,7 +49,6 @@ export default {
 #static {
   box-sizing: border-box;
   @include for-desktop {
-    max-width: 1272px;
     padding: 0 var(--spacer-sm);
     margin: 0 auto;
   }


### PR DESCRIPTION
Removed overridden padding on section
Removed overridden height for hero banner
Used the global class for max-width instead of the CSS property


Before

![HOmebefore](https://user-images.githubusercontent.com/8766155/92241726-584eda80-eedc-11ea-8878-c3dc46bcddf2.png)


After


![homeafter](https://user-images.githubusercontent.com/8766155/92241719-571dad80-eedc-11ea-951e-c6e58938031e.png)
