### PR TITLE
Improved: banner background postion for some banners in homepage (#1na09d)

### DIFF
--- a/components/organisms/o-banner-grid.vue
+++ b/components/organisms/o-banner-grid.vue
@@ -62,4 +62,7 @@ export default {
     margin: var(--spacer-2xl) 0;
   }
 }
+.sf-banner-grid.banner-grid .sf-banner-grid__row:first-child .sf-banner {
+  background-position-y: bottom;
+}
 </style>


### PR DESCRIPTION
Set banner's background-position to bottom for 2 banners using css rule


Closes: https://app.clickup.com/t/1na09d

Screenshots:

Before

![bannersectionbefore](https://user-images.githubusercontent.com/8766155/98963129-52552580-252d-11eb-9799-0c5628d962d1.gif)

After

![bannersectionafter](https://user-images.githubusercontent.com/8766155/98963152-584b0680-252d-11eb-80fc-c3c5e35b757a.gif)
