### PR TITLE
Updated: the code to register the module on creation (#1nduw8)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Peregrine CMS Module for Vue Storefront
 
+## 2.3.0 (Upcoming release)
+- Updated: the code to register the module on creation (#1nduw8)
+
 ## 2.2.0 (2020-10-13)
 - Updated code as per peregrine cms 2.0
 - Added wishlist icons in product card on product carousel

--- a/pages/Static.vue
+++ b/pages/Static.vue
@@ -17,7 +17,6 @@ export default {
     CmsPage
   },
   async beforeCreate () {
-    console.log('working')
     await registerModule(PeregrineModule)
     if(this.$router.currentRoute.path === '/') {
       await this.$store.dispatch('cmspage/getCmsComponents', { title: 'index' })

--- a/pages/Static.vue
+++ b/pages/Static.vue
@@ -9,10 +9,19 @@ import i18n from '@vue-storefront/i18n';
 import config from 'config';
 import { mapGetters } from 'vuex';
 import CmsPage from '../components/CmsPage';
+import { registerModule } from '@vue-storefront/core/lib/modules';
+import { PeregrineModule } from 'src/modules/peregrine';
 
 export default {
   components: {
     CmsPage
+  },
+  async beforeCreate () {
+    console.log('working')
+    await registerModule(PeregrineModule)
+    if(this.$router.currentRoute.path === '/') {
+      await this.$store.dispatch('cmspage/getCmsComponents', { title: 'index' })
+    }
   },
   metaInfo () {
     return {


### PR DESCRIPTION
The changes will help up to register the Peregrine Module on-demand.
Used the beforeCreate hook to register module and then checking the route to render the Home page.