### PR TITLE
Implemented: a custom carousel component to solve the duplicate image issue in best seller(#1qg127)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 2.3.0 (Upcoming release)
 - Updated: the code to register the module on creation (#1nduw8)
+- Implemented: a custom carousel component to solve the duplicate image issue in best seller(#1qg127)
 
 ## 2.2.0 (2020-10-13)
 - Updated code as per peregrine cms 2.0

--- a/components/molecules/m-carousel.vue
+++ b/components/molecules/m-carousel.vue
@@ -1,0 +1,146 @@
+<template>
+  <div class="sf-carousel">
+    <div v-if="client" ref="controls" class="sf-carousel__controls">
+      <!--@slot slot for icon moving to the previous item -->
+      <slot name="prev" v-bind="{ go: () => go('prev') }">
+        <SfArrow aria-label="previous" @click="go('prev')" />
+      </slot>
+      <!--@slot slot for icon moving to the next item -->
+      <slot name="next" v-bind="{ go: () => go('next') }">
+        <SfArrow
+          aria-label="next"
+          class="sf-arrow--right"
+          @click="go('next')"
+        />
+      </slot>
+    </div>
+    <div class="sf-carousel__wrapper">
+      <div ref="glide" class="glide">
+        <div class="glide__track" data-glide-el="track">
+          <ul class="glide__slides sf-carousel__slides">
+            <!--@slot default slot for SfCarouselItem tags -->
+            <slot />
+          </ul>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+<script>
+import Vue from "vue";
+import SfCarouselItem from "@storefront-ui/vue/src/components/organisms/SfCarousel/_internal/SfCarouselItem.vue";
+import { SfArrow } from "@storefront-ui/vue";
+import Glide from "@glidejs/glide";
+
+const isClient = (() =>
+  typeof window !== "undefined" || typeof document !== "undefined")();
+
+Vue.component("SfCarouselItem", SfCarouselItem);
+export default {
+  name: "MCarousel",
+  components: {
+    SfArrow,
+  },
+  props: {
+    settings: {
+      type: Object,
+      default: () => ({}),
+    },
+  },
+  data() {
+    return {
+      client: isClient,
+      glide: null,
+      defaultSettings: {
+        type: "carousel",
+        rewind: true,
+        perView: 4,
+        slidePerPage: true,
+        gap: 0,
+        breakpoints: {
+          1023: {
+            perView: 2,
+            peek: {
+              before: 0,
+              after: 50,
+            },
+          },
+        },
+      },
+    };
+  },
+  computed: {
+    mergedOptions() {
+      let breakpoints = { ...this.defaultSettings.breakpoints };
+      if (this.settings.breakpoints) {
+        breakpoints = { ...breakpoints, ...this.settings.breakpoints };
+      }
+      return {
+        ...this.defaultSettings,
+        ...this.settings,
+        breakpoints: breakpoints,
+      };
+    },
+  },
+  mounted: function () {
+    this.$nextTick(() => {
+      if (!this.$slots.default) return;
+      const glide = new Glide(this.$refs.glide, this.mergedOptions);
+      const size = this.$slots.default.filter((slot) => slot.tag).length;
+      if (size <= glide.settings.perView) {
+        glide.settings.perView = size;
+        glide.settings.rewind = false;
+        this.$refs.controls.style.display = "none";
+      }
+      glide.mount();
+      glide.on("run.before", (move) => {
+        const { slidePerPage, rewind, type } = this.mergedOptions;
+        if (!slidePerPage) return;
+        const { perView } = glide.settings;
+        if (!perView > 1) return;
+        const { direction } = move;
+        let page, newIndex;
+        switch (direction) {
+          case ">":
+          case "<":
+            page = Math.ceil(glide.index / perView);
+            newIndex =
+              page * perView + (direction === ">" ? perView : -perView);
+            if (newIndex >= size) {
+              if (type === "slider" && !rewind) {
+                newIndex = glide.index;
+              } else {
+                newIndex = 0;
+              }
+            } else if (newIndex < 0 || newIndex + perView > size) {
+              if (type === "slider" && !rewind) {
+                newIndex = glide.index;
+              } else {
+                newIndex = size - perView;
+              }
+            }
+            move.direction = "=";
+            move.steps = newIndex;
+        }
+      });
+      this.glide = glide;
+    });
+  },
+  methods: {
+    go(direct) {
+      if (!this.glide) return;
+      switch (direct) {
+        case "prev":
+          this.glide.go("<");
+          break;
+        case "next":
+          this.glide.go(">");
+          break;
+      }
+    },
+  },
+};
+</script>
+<style lang="scss" scoped>
+@import "~@storefront-ui/shared/styles/components/organisms/SfCarousel.scss";
+</style>

--- a/components/organisms/o-product-carousel.vue
+++ b/components/organisms/o-product-carousel.vue
@@ -2,7 +2,7 @@
   <div v-if="carouselProducts.length">
     <SfSection :title-heading="componentData.title" class="section">
       <div>
-        <SfCarousel
+        <MCarousel
           class="m-product-carousel"
           :settings="{
             animationDuration: 3000,
@@ -23,14 +23,15 @@
               link-tag="router-link"
             />
           </SfCarouselItem>
-        </SfCarousel>
+        </MCarousel>
       </div>
     </SfSection>
   </div>
 </template>
 
 <script>
-import { SfProductCard, SfCarousel, SfSection } from '@storefront-ui/vue';
+import { SfProductCard, SfSection } from '@storefront-ui/vue';
+import MCarousel from '../molecules/m-carousel'
 import fetch from 'isomorphic-fetch';
 import { prepareCategoryProduct } from 'theme/helpers';
 import { mapGetters, mapActions } from 'vuex';
@@ -42,8 +43,8 @@ import { htmlDecode } from '@vue-storefront/core/filters';
 export default {
   components: {
     SfProductCard,
-    SfCarousel,
-    SfSection
+    SfSection,
+    MCarousel
   },
   mixins: [AAddToWishlist],
   props: {


### PR DESCRIPTION
The duplicate image issue is because the perView for the carousel is greater than the number of products in the best seller component, hence it duplicate the products to match it with the perView of the carousel.

The issue is fixed in the latest release of the StorefrontUI (0.10.1).

Backported the fixes in a custom component to solve the issue.
