### PR TITLE
Improved: code to handle the direct access of static pages in peregrine module(#1nduw8)

### DIFF
--- a/pages/Static.vue
+++ b/pages/Static.vue
@@ -20,6 +20,9 @@ export default {
     await registerModule(PeregrineModule)
     if(this.$router.currentRoute.path === '/') {
       await this.$store.dispatch('cmspage/getCmsComponents', { title: 'index' })
+    } else {
+      this.$route.name === 'cms-page' ? await this.$store.dispatch('cmspage/getCmsComponents', { title: this.$route.params.slug }) : await this.$store.dispatch('cmspage/getCmsComponents', { title: this.$route.name })
+
     }
   },
   metaInfo () {


### PR DESCRIPTION
### Problem:
When accessing the static pages directly, then the request to peregrine is not completed and no content is displayed on the page.


### Solution:
Handled the issue by adding a condition to check for home and static pages and then redirecting as per the route param.
