### PR TITLE
Improved: code to access the home page on initial render and updated …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Peregrine CMS Module for Vue Storefront
 
-## 2.3.1 (Upcoming Release)
+## 2.3.2 (2021-04-24)
+- Improved: code to handle the multistore setup in VSF(#299cgq)
+- Improved: code to handle the direct access of static pages in peregrine module(#1nduw8)
+- Improved: code by defining CmsPage as functional and passing the components as a prop(#2bc303)
+
+## 2.3.1 (2021-02-05)
 - Implemented: a custom carousel component to solve the duplicate image issue in best seller(#1qg127)
 - Improved: code to handle the multistore setup in VSF(#299cgq)
 

--- a/pages/Static.vue
+++ b/pages/Static.vue
@@ -45,7 +45,7 @@ export default {
     await registerModule(PeregrineModule)
     let storeView = currentStoreView()
     let routeTo = this.$route.name
-    console.log(routeTo, this.$router.currentRoute)
+
     if (this.$router.currentRoute.path === `/${storeView.storeCode}` || this.$router.currentRoute.path === `/${storeView.storeCode}/`) {
       await this.$store.dispatch('cmspage/getCmsComponents', { title: 'index', locale: storeView.i18n.defaultLocale })
     } else {

--- a/router/beforeEach.ts
+++ b/router/beforeEach.ts
@@ -10,7 +10,8 @@ export async function beforeEach (to: Route, from: Route, next) {
   let routeTo = to.name
   let storeView = currentStoreView()
 
-  if (routeTo.includes('it') || routeTo.includes('de')) {
+  // TODO: find a more efficient way to handle the multi-store setup
+  if (routeTo.indexOf('it') == 0 || routeTo.indexOf('de') == 0) {
     routeTo = routeTo.substring(routeTo.indexOf('-') + 1)
   }
   if (routeTo === 'cms-page') {


### PR DESCRIPTION
…code to use indexOf instead of using includes for checking store code (#1nduw8)


Current Issue:
1. When clicking the home icon in the multi-store setup from any page then the link for the home page prepared is `/<store-code>/` which results in an empty page.
2. When using `includes` to check for the presence of store-code in the url, then the page `size-guide` matches with the store-code `de` and then make a request for the `size.data.json` page.

Solution:
1. Currently, added a condition in the if, to check for the `/<store-code>/` url as well.
2. Used `indexOf` instead of `includes` and also checking whether the index is equal to 0 or not, because always the store-code is present in the start of the url.