### PR TITLE
Improved: code to open the external urls in a new tab(#cx8r86)

### DIFF
--- a/changelogs/unreleased/-cx8r86.yml
+++ b/changelogs/unreleased/-cx8r86.yml
@@ -1,0 +1,6 @@
+---
+title: 'Improved: code to open the external urls in a new tab'
+ticket_id: "#cx8r86"
+merge_request: 123
+author: Yash Maheshwari
+type: changed

--- a/mixins/LinkMixin.js
+++ b/mixins/LinkMixin.js
@@ -25,7 +25,7 @@ export default {
           // condition handles the link type of url and also checks for empty link
         } else if (linkType !== '') {
           let url = link.match(/^https?:/) ? link : 'https://' + link;
-          window.open(url, '_self');
+          window.open(url, '_blank');
         }
       }
     }


### PR DESCRIPTION
**Issue**
When we have an external link then the link was opening in the same tab.

**Solution**
Used _blank in window open function to open an external link in a new tab.